### PR TITLE
Use minimum API level 16 for people running patched app on 4.1+

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "de.rastapasta.android.xposed.pokemongo"
-        minSdkVersion 19
+        minSdkVersion 16
         targetSdkVersion 23
         versionCode 2
         versionName "1.1"


### PR DESCRIPTION
The current version of the app reportedly works on 4.1, so might as well allow this Xposed module to be used on 4.1+.
